### PR TITLE
Fix reflection exception on virtual type (fix #9)

### DIFF
--- a/dev/phpunit/functional/FunctionalTests.php
+++ b/dev/phpunit/functional/FunctionalTests.php
@@ -20,11 +20,12 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
         $this->assertFileExists(BASE_DIR . '/dev/instances/magento21/app/etc/env.php', "Magento 2.1 is not installed");
 
         exec($this->generateAnalyseCommand('/dev/instances/magento21'), $output, $return);
+        $this->assertEquals(0, $return, "The return code of the command was not zero");
+
         $lastLine = array_pop($output);
         $this->assertStringStartsWith('You should review the above', $lastLine);
         $output = implode(PHP_EOL, $output);
 
-        $this->assertEquals(0, $return, "The return code of the command was not zero");
         $this->assertEquals(\file_get_contents(BASE_DIR . '/dev/phpunit/functional/expected_output/magento21.out.txt'), $output);
     }
 
@@ -36,12 +37,34 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
         $this->assertFileExists(BASE_DIR . '/dev/instances/magento22/app/etc/env.php', "Magento 2.2 is not installed");
 
         exec($this->generateAnalyseCommand('/dev/instances/magento22'), $output, $return);
+        $this->assertEquals(0, $return, "The return code of the command was not zero");
+
         $lastLine = array_pop($output);
         $this->assertStringStartsWith('You should review the above', $lastLine);
         $output = implode(PHP_EOL, $output);
 
-        $this->assertEquals(0, $return, "The return code of the command was not zero");
         $this->assertEquals(\file_get_contents(BASE_DIR . '/dev/phpunit/functional/expected_output/magento22.out.txt'), $output);
+    }
+
+    /**
+     * @link https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/9
+     * @depends testMagentoTwoTwo
+     * @group v22
+     */
+    public function testVirtualTypesNoException()
+    {
+        copy(
+            BASE_DIR . '/dev/phpunit/functional/resources/reflection-exception.diff',
+            BASE_DIR . '/dev/instances/magento22/vendor.patch'
+        );
+        $this->assertFileEquals(
+            BASE_DIR . '/dev/phpunit/functional/resources/reflection-exception.diff',
+            BASE_DIR . '/dev/instances/magento22/vendor.patch',
+            "vendor.patch did not update for this test"
+        );
+
+        exec($this->generateAnalyseCommand('/dev/instances/magento22'), $output, $return);
+        $this->assertEquals(0, $return, "The return code of the command was not zero");
     }
 
     /**
@@ -54,11 +77,12 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
         $this->markTestSkipped('We need to run this as an install of 2.2 being upgraded to 2.3 but this breaks due to https://github.com/magento/magento2/issues/19446');
 
         exec($this->generateAnalyseCommand('/dev/instances/magento23'), $output, $return);
+        $this->assertEquals(0, $return, "The return code of the command was not zero");
+
         $output = implode(PHP_EOL, $output);
         $lastLine = array_pop($output);
         $this->assertStringStartsWith('You should review the above', $lastLine);
 
-        $this->assertEquals(0, $return, "The return code of the command was not zero");
         $this->assertEquals(\file_get_contents(BASE_DIR . '/dev/phpunit/functional/expected_output/magento23.out.txt'), $output);
     }
 }

--- a/dev/phpunit/functional/resources/reflection-exception.diff
+++ b/dev/phpunit/functional/resources/reflection-exception.diff
@@ -1,0 +1,28 @@
+diff -ur vendor_orig/magento/module-catalog/Model/ResourceModel/Product/BaseSelectProcessorInterface.php vendor/magento/module-catalog/Model/ResourceModel/Product/BaseSelectProcessorInterface.php
+--- vendor_orig/magento/module-catalog/Model/ResourceModel/Product/BaseSelectProcessorInterface.php	2018-07-28 12:17:02.000000000 +0100
++++ vendor/magento/module-catalog/Model/ResourceModel/Product/BaseSelectProcessorInterface.php	2018-11-28 15:25:56.000000000 +0000
+@@ -1,6 +1,6 @@
+ <?php
+ /**
+- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
++ * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+ namespace Magento\Catalog\Model\ResourceModel\Product;
+@@ -9,6 +9,8 @@
+ 
+ /**
+  * Interface BaseSelectProcessorInterface
++ * @api
++ * @since 101.0.3
+  */
+ interface BaseSelectProcessorInterface
+ {
+@@ -20,6 +22,7 @@
+     /**
+      * @param Select $select
+      * @return Select
++     * @since 101.0.3
+      */
+     public function process(Select $select);
+ }

--- a/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
+++ b/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
@@ -60,7 +60,7 @@ class AnalyseCommand extends Command
                     }
                 }
             } catch (\InvalidArgumentException $e) {
-                $output->writeln("<error>Could not understand $file</error>", OutputInterface::VERBOSITY_VERY_VERBOSE);
+                $output->writeln("<error>Could not understand $file: {$e->getMessage()}</error>", OutputInterface::VERBOSITY_VERY_VERBOSE);
             }
         }
 

--- a/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
+++ b/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
@@ -293,14 +293,11 @@ class PatchOverrideValidator
             return false;
         }
 
-        if ($preference === 'interceptionConfigScope') {
-            /**
-             * This catches vendor/magento/framework/Config/ScopeListInterface.php
-             */
-            return false;
+        try {
+            $refClass = new \ReflectionClass($preference);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException("Could not instantiate $preference (virtualType?)");
         }
-
-        $refClass = new \ReflectionClass($preference);
         $path = realpath($refClass->getFileName());
 
         $pathsToIgnore = [


### PR DESCRIPTION
See #9 

Certain classes cannot be instantiated by reflection.

Add a try/catch and pass the exception back up so that we still get it output in the `-vvv` mode.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
