### PR TITLE
Fix travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php: 7.2
+dist: trusty
 
 env:
   - TEST_GROUP=21


### PR DESCRIPTION
https://docs.travis-ci.com/user/database-setup/#mysql

Mysql 5.6 was not available for install due to updates to travis

![Screenshot 2019-07-02 at 09 37 42](https://user-images.githubusercontent.com/600190/60497595-0f364180-9cad-11e9-8c11-e6e001072926.png)

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
