### PR TITLE
Add additional error handling

### DIFF
--- a/dev/phpunit/functional/FunctionalTests.php
+++ b/dev/phpunit/functional/FunctionalTests.php
@@ -86,6 +86,27 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @link https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/9
+     * @depends testMagentoTwoThree
+     * @group v23
+     */
+    public function testUnifiedDiffIsProvided()
+    {
+        copy(
+            BASE_DIR . '/dev/phpunit/functional/resources/not-a-unified-diff.txt',
+            BASE_DIR . '/dev/instances/magento23/vendor.patch'
+        );
+        $this->assertFileEquals(
+            BASE_DIR . '/dev/phpunit/functional/resources/not-a-unified-diff.txt',
+            BASE_DIR . '/dev/instances/magento23/vendor.patch',
+            "vendor.patch did not update for this test"
+        );
+
+        exec($this->generateAnalyseCommand('/dev/instances/magento23'), $output, $return);
+        $this->assertEquals(1, $return);
+    }
+
+    /**
      * @group v23
      */
     public function testMagentoTwoThree()

--- a/dev/phpunit/functional/resources/not-a-unified-diff.txt
+++ b/dev/phpunit/functional/resources/not-a-unified-diff.txt
@@ -1,0 +1,9 @@
+diff --git a/README.md b/README.md
+index 5f3bc7d..3a7c59c 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,4 @@
++
+ # ampersand-magento2-upgrade-patch-helper
+
+ Helper scripts to aid upgrading magento 2 websites

--- a/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
+++ b/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
@@ -40,7 +40,12 @@ class AnalyseCommand extends Command
 
         $summaryOutputData = [];
         $patchFilesToOutput = [];
-        foreach ($patchFile->getFiles() as $patchFile) {
+        $patchFiles = $patchFile->getFiles();
+        if (empty($patchFiles)) {
+            $output->writeln("<error>The patch file could not be parsed, are you sure its a unified diff? </error>");
+            return;
+        }
+        foreach ($patchFiles as $patchFile) {
             $file = $patchFile->getPath();
             try {
                 $patchOverrideValidator = new Helper\PatchOverrideValidator($magento2, $patchFile);

--- a/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
+++ b/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
@@ -43,7 +43,7 @@ class AnalyseCommand extends Command
         $patchFiles = $patchFile->getFiles();
         if (empty($patchFiles)) {
             $output->writeln("<error>The patch file could not be parsed, are you sure its a unified diff? </error>");
-            return;
+            return 1;
         }
         foreach ($patchFiles as $patchFile) {
             $file = $patchFile->getPath();


### PR DESCRIPTION
Add some tests to assert the generated `vendor.patch` is correct.  Currently a bad input just says there are no files to review and this could confuse and mean people don't actually review the upgrade.

```bash
+------+------+----------+
| Type | Core | To Check |
+------+------+----------+
You should review the above 0 items alongside /host/magento/vendor_files_to_check.patch
```

The new output will show an error message and a non zero return code.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
