### PR TITLE
Fix theme load error if theme is set using DI

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -1,12 +1,10 @@
 <?php
 namespace Ampersand\PatchHelper\Helper;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\ObjectManager\ConfigInterface;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\View\Design\FileResolution\Fallback\Resolver\Minification;
 use Magento\Framework\View\DesignInterface;
-use Magento\Theme\Model\Theme\ThemeProvider;
+use Magento\Framework\View\Design\Theme\FlyweightFactory;
 
 class Magento2Instance
 {
@@ -14,7 +12,6 @@ class Magento2Instance
     private $app;
 
     /** @var \Magento\Framework\ObjectManagerInterface $objectManager */
-
     private $objectManager;
 
     /** @var \Magento\Framework\ObjectManager\ConfigInterface */
@@ -49,10 +46,14 @@ class Magento2Instance
 
         // Frontend theme
         $this->minificationResolver = $objectManager->get(Minification::class);
-        $scopeConfig = $objectManager->get(ScopeConfigInterface::class);
-        $themeId = $scopeConfig->getValue(DesignInterface::XML_PATH_THEME_ID, 'stores');
-        $themeProvider = $objectManager->get(ThemeProvider::class);
-        $this->currentTheme = $themeProvider->getThemeById($themeId);
+        /** @var \Magento\Framework\View\DesignInterface $designModel */
+        $designModel = $objectManager->get(DesignInterface::class);
+        /** @var \Magento\Framework\View\Design\Theme\FlyweightFactory $flyWeightFactory */
+        $flyWeightFactory = $objectManager->get(FlyweightFactory::class);
+        $this->currentTheme = $flyWeightFactory->create(
+            $designModel->getConfigurationDesignTheme(DesignInterface::DEFAULT_AREA),
+            DesignInterface::DEFAULT_AREA
+        );
         if (!$this->currentTheme->getId()) {
             throw new \Exception('Unable to load current theme');
         }


### PR DESCRIPTION
The original method for resolving a theme ID expected a store to have the ID set in the DB/`config.xml`. If a sites theme was set using DI however, eg:
```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="Magento\Theme\Model\View\Design">
        <arguments>
            <argument name="themes" xsi:type="array">
                <item name="frontend" xsi:type="string">Vendor/default</item>
            </argument>
        </arguments>
    </type>
</config>
```
loading the theme would fail. This PR updates the functionality to use the `getConfigurationDesignTheme` method in `\Magento\Framework\View\DesignInterface` which will resolve the theme ID by first checking the DB/`config.xml`, falling back to the arguments passed in the constructor if a falsy value is found. This method and supporting functionality has been around since v2.0 so should be backwards compatible https://github.com/magento/magento2/blob/2.0/app/code/Magento/Theme/Model/View/Design.php#L162

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
