### PR TITLE
Only find frontend overwritten files for frontend themes and likewise for adminhtml themes

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
+++ b/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
@@ -359,7 +359,7 @@ class PatchOverrideValidator
         $module = $parts[2] . '_' . $parts[3];
         $key = $type === 'static' ? '/web/' : '/templates/';
         $name = str_replace($key, '', strstr($file, $key));
-        $themes = $this->m2->getCustomThemes();
+        $themes = $this->m2->getCustomThemes($area);
         foreach ($themes as $theme) {
             $path = $this->m2->getMinificationResolver()->resolve($type, $name, $area, $theme, null, $module);
 


### PR DESCRIPTION
While working with this tool during an upgrade of Magento 2.2.7 to 2.3.5-p2 I noticed something strange.

We had the following file in our custom frontend theme: `app/design/frontend/Vendor/custom/Magento_Captcha/templates/default.phtml`

When running this tool, it reported the following two files to have been overwritten by this file:
```
vendor/magento/module-captcha/view/adminhtml/templates/default.phtml
vendor/magento/module-captcha/view/frontend/templates/default.phtml
```

The first one is obviously incorrect.
This PR fixes that.

In theory it should also work for custom adminhtml themes I think, but I never tested that.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
