### PR TITLE
Fix bug where tool exits with 0 code, no errors, and no output

### DIFF
--- a/dev/setup-magento-with-diff.sh
+++ b/dev/setup-magento-with-diff.sh
@@ -47,7 +47,7 @@ php -d memory_limit=1024M bin/magento setup:install \
 
 # Set developer mode
 php bin/magento deploy:mode:set developer
-
+php bin/magento config:set web/url/redirect_to_base 0
 # Generate patch file for analysis
 diff -ur vendor_orig/ vendor/ > vendor.patch || true
 

--- a/dev/setup-magento-with-diff.sh
+++ b/dev/setup-magento-with-diff.sh
@@ -47,7 +47,11 @@ php -d memory_limit=1024M bin/magento setup:install \
 
 # Set developer mode
 php bin/magento deploy:mode:set developer
+
+# See the comment in src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+# This helps replicate a bug in which the tool exits with a 0 and no output
 php bin/magento config:set web/url/redirect_to_base 0
+
 # Generate patch file for analysis
 diff -ur vendor_orig/ vendor/ > vendor.patch || true
 

--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -37,6 +37,36 @@ class Magento2Instance
 
     public function __construct($path)
     {
+        /**
+         * Ensure the application thinks this is a POST request. This prevents it from hitting the below function
+         *
+         * This can happen in some scenarios but most simply
+         * 1. Full page cache is enabled with a type like varnish, or the default file cache on a clean cache
+         * 2. web/url/redirect_to_base = false, although there a bunch of other conditions that can cause it
+         *
+         * Without this change the application will return a 0 exit code with no output at all.
+         *
+         * # vendor/magento/framework/App/Router/Base.php
+         *
+         *  protected function _checkShouldBeSecure(\Magento\Framework\App\RequestInterface $request, $path = '')
+         *  {
+         *      if ($request->getPostValue()) {
+         *          return;
+         *      }
+         *      if ($this->pathConfig->shouldBeSecure($path) && !$request->isSecure()) {
+         *          $url = $this->pathConfig->getCurrentSecureUrl($request);
+         *          if ($this->_shouldRedirectToSecure()) {
+         *              $url = $this->_url->getRedirectUrl($url);
+         *          }
+         *          $this->_responseFactory->create()->setRedirect($url)->sendResponse();
+         *          // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
+         *          exit;
+         *      }
+         *  }
+         */
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['ampersand_upgrade_patch_helper'] = 'force_post';
+
         require rtrim($path, '/') . '/app/bootstrap.php';
 
         /** @var \Magento\Framework\App\Bootstrap $bootstrap */


### PR DESCRIPTION
Ensure the application thinks this is a POST request. This prevents it from hitting the below function  
                                                                                                        
This can happen in some scenarios but most simply                                                       
1. Full page cache is enabled with a type like varnish, or the default file cache on a clean cache      
2. `web/url/redirect_to_base = false`, although there a bunch of other conditions that can cause it       
                                                                                                        
Without this change the application will return a 0 exit code with no output at all.                    
                    
```php                                                                                    
# vendor/magento/framework/App/Router/Base.php                                                          
                                                                                                        
 protected function _checkShouldBeSecure(\Magento\Framework\App\RequestInterface $request, $path = '')  
 {                                                                                                      
     if ($request->getPostValue()) {                                                                    
         return;                                                                                        
     }                                                                                                  
     if ($this->pathConfig->shouldBeSecure($path) && !$request->isSecure()) {                           
         $url = $this->pathConfig->getCurrentSecureUrl($request);                                       
         if ($this->_shouldRedirectToSecure()) {                                                        
             $url = $this->_url->getRedirectUrl($url);                                                  
         }                                                                                              
         $this->_responseFactory->create()->setRedirect($url)->sendResponse();                          
         // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage                                  
         exit;                                                                                          
     }                                                                                                  
 }                                                                                                      
```

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
