### PR TITLE
Fix issue where no custom themes breaks the tool

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -96,9 +96,6 @@ class Magento2Instance
                 break;
             }
         }
-        if (empty($this->customFrontendThemes) && empty($this->customAdminThemes)) {
-            throw new \Exception('Unable to find custom theme(s)');
-        }
 
         // Config per area
         $configLoader = $objectManager->get(\Magento\Framework\ObjectManager\ConfigLoaderInterface::class);


### PR DESCRIPTION
See https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/40

Having no custom theme at all makes this tool unusable

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
