### PR TITLE
Fix compatibility with new magento versions

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -44,11 +44,7 @@ class Magento2Instance
         $application = $bootstrap->createApplication(\Magento\Framework\App\Http::class);
         $objectManager = $bootstrap->getObjectManager();
         $this->objectManager = $objectManager;
-
-        $cacheState = $objectManager->get(\Magento\Framework\App\Cache\State::class);
-        $cacheState->setEnabled('full_page', false);
-
-        $this->app = $application->launch();
+        //$this->app = $application->launch();
 
         $this->config = $objectManager->get(ConfigInterface::class);
 

--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -37,43 +37,18 @@ class Magento2Instance
 
     public function __construct($path)
     {
-        /**
-         * Ensure the application thinks this is a POST request. This prevents it from hitting the below function
-         *
-         * This can happen in some scenarios but most simply
-         * 1. Full page cache is enabled with a type like varnish, or the default file cache on a clean cache
-         * 2. web/url/redirect_to_base = false, although there a bunch of other conditions that can cause it
-         *
-         * Without this change the application will return a 0 exit code with no output at all.
-         *
-         * # vendor/magento/framework/App/Router/Base.php
-         *
-         *  protected function _checkShouldBeSecure(\Magento\Framework\App\RequestInterface $request, $path = '')
-         *  {
-         *      if ($request->getPostValue()) {
-         *          return;
-         *      }
-         *      if ($this->pathConfig->shouldBeSecure($path) && !$request->isSecure()) {
-         *          $url = $this->pathConfig->getCurrentSecureUrl($request);
-         *          if ($this->_shouldRedirectToSecure()) {
-         *              $url = $this->_url->getRedirectUrl($url);
-         *          }
-         *          $this->_responseFactory->create()->setRedirect($url)->sendResponse();
-         *          // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
-         *          exit;
-         *      }
-         *  }
-         */
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-        $_POST['ampersand_upgrade_patch_helper'] = 'force_post';
-
         require rtrim($path, '/') . '/app/bootstrap.php';
 
         /** @var \Magento\Framework\App\Bootstrap $bootstrap */
         $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
-        $this->app = $bootstrap->createApplication(\Magento\Framework\App\Http::class)->launch();
+        $application = $bootstrap->createApplication(\Magento\Framework\App\Http::class);
         $objectManager = $bootstrap->getObjectManager();
         $this->objectManager = $objectManager;
+
+        $cacheState = $objectManager->get(\Magento\Framework\App\Cache\State::class);
+        $cacheState->setEnabled('full_page', false);
+
+        $this->app = $application->launch();
 
         $this->config = $objectManager->get(ConfigInterface::class);
 


### PR DESCRIPTION
Fix issue https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/45

In https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/pull/39 we forced the application to think it's a POST request so we could get around a check like 

```php
     if ($request->getPostValue()) {                                                                    
         return;                                                                                        
     }                                                                                                  
```

This now caught another part of the application now where we had to set a cookie which fails.

This raises the greater question, why are we launching the http application at all? It has been present since the first version of the script (see  https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/commit/0fe0b2d656897b27c46c50ec94cea037543cc495#diff-4f20f6cc6d8cd1e15362898e43a1555166b9e25f3c5da5f1f78ab614bf1b8bf2R20) 

After discussing with @hostep I am going to remove the launching of the http application entirely. The test cases we have covered still go green in travis, and any new issues that arise from this we will know how to revert and work review how to work around.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
