### PR TITLE
Fix exception with custom library names

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
+++ b/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
@@ -488,6 +488,14 @@ class PatchOverrideValidator
 
         foreach ($this->m2->getListOfPathsToLibrarys() as $libraryPath => $libraryName) {
             if (!$this->isMagentoExtendable && str_starts_with($path, $libraryPath)) {
+                // Handle libraries with names like Thirdparty_LibraryName
+                if (!str_contains($libraryName, '/') && str_contains($libraryName, '_')) {
+                    $pathToUse = $libraryPath;
+                    $this->isMagentoExtendable = true;
+                    list($namespace, $module) = explode('_', $libraryName);
+                    break;
+                }
+
                 // Input libraryName magento-super/framework-explosion-popice
                 // Output namespace = MagentoSuper | module = FrameworkExplosionPopice
                 list($tmpNamespace, $tmpModule) = explode('/', $libraryName);


### PR DESCRIPTION
```
In PatchOverrideValidator.php line 493:
                       
  Undefined offset: 1  
```

A third party module has a non standard naming format, handle those scenarios.

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
