### PR TITLE
Fix override path for relative project dir.

### DIFF
--- a/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
+++ b/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
@@ -90,7 +90,7 @@ class AnalyseCommand extends Command
                         $patchFilesToOutput[$file] = $patchFile;
                     }
                     foreach ($errors as $error) {
-                        $summaryOutputData[] = [$errorType, $file, ltrim(str_replace($projectDir, '', $error), '/')];
+                        $summaryOutputData[] = [$errorType, $file, ltrim(str_replace(realpath($projectDir), '', $error), '/')];
                         if ($errorType === Helper\PatchOverrideValidator::TYPE_FILE_OVERRIDE
                             && $input->getOption('auto-theme-update') && is_numeric($input->getOption('auto-theme-update'))) {
                             $patchFile->applyToTheme($projectDir, $error, $input->getOption('auto-theme-update'));


### PR DESCRIPTION
When providing a relative project directory such as ../../magento rather
than a full path /Users/pocallaghan/sites/magento the project root was
not correctly stripped from the "To" column in the output.

Fix by resolving the path using realpath before stripping it off.

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
