### PR TITLE
Fix handling of non-absolute magento path when outputting results

### DIFF
--- a/dev/phpunit/functional/FunctionalTests.php
+++ b/dev/phpunit/functional/FunctionalTests.php
@@ -174,7 +174,7 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
     {
         $this->assertFileExists(BASE_DIR . '/dev/instances/magento24/app/etc/env.php', "Magento 2.4 is not installed");
 
-        exec($this->generateAnalyseCommand('/dev/instances/magento24', '--sort-by-type --vendor-namespaces Ampersand'), $output, $return);
+        exec($this->generateAnalyseCommand('/dev/instances/../instances/magento24', '--sort-by-type --vendor-namespaces Ampersand'), $output, $return);
         $this->assertEquals(0, $return, "The return code of the command was not zero");
 
         $lastLine = array_pop($output);

--- a/dev/phpunit/functional/FunctionalTests.php
+++ b/dev/phpunit/functional/FunctionalTests.php
@@ -204,7 +204,7 @@ class FunctionalTests extends \PHPUnit\Framework\TestCase
         $this->assertFileExists(BASE_DIR . '/dev/instances/magento24nodb/app/etc/di.xml', "Magento 2.4 directory is wrong");
         $this->assertFileNotExists(BASE_DIR . '/dev/instances/magento24nodb/app/etc/env.php', "Magento 2.4 is installed when it shouldnt be");
 
-        exec($this->generateAnalyseCommand('/dev/instances/magento24nodb', '--sort-by-type --vendor-namespaces Ampersand'), $output, $return);
+        exec($this->generateAnalyseCommand('/dev/instances/../instances/magento24nodb', '--sort-by-type --vendor-namespaces Ampersand'), $output, $return);
         $this->assertEquals(0, $return, "The return code of the command was not zero");
 
         $lastLine = array_pop($output);

--- a/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
+++ b/src/Ampersand/PatchHelper/Command/AnalyseCommand.php
@@ -90,7 +90,7 @@ class AnalyseCommand extends Command
                         $patchFilesToOutput[$file] = $patchFile;
                     }
                     foreach ($errors as $error) {
-                        $summaryOutputData[] = [$errorType, $file, ltrim(str_replace($projectDir, '', $error), '/')];
+                        $summaryOutputData[] = [$errorType, $file, ltrim(str_replace(realpath($projectDir), '', $error), '/')];
                         if ($errorType === Helper\PatchOverrideValidator::TYPE_FILE_OVERRIDE
                             && $input->getOption('auto-theme-update') && is_numeric($input->getOption('auto-theme-update'))) {
                             $patchFile->applyToTheme($projectDir, $error, $input->getOption('auto-theme-update'));


### PR DESCRIPTION
This PR https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/pull/56 with a little test manipulation to verify it

```diff
-| Override (phtml/js/html) | vendor/magento/module-catalog/view/frontend/layout/catalog_category_view.xml          | app/design/frontend/Ampersand/theme/Magento_Catalog/layout/catalog_category_view.xml        |\n
+| Override (phtml/js/html) | vendor/magento/module-catalog/view/frontend/layout/catalog_category_view.xml          | home/travis/build/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/dev/instances/magento24nodb/app/design/frontend/Ampersand/theme/Magento_Catalog/layout/catalog_category_view.xml        |\n
```

We were getting weird output like above

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
