### PR TITLE
[WIP] Adds support for detecting overwritten custom frontend files on top o…

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
+++ b/src/Ampersand/PatchHelper/Helper/PatchOverrideValidator.php
@@ -490,6 +490,22 @@ class PatchOverrideValidator
                 $this->isMagentoExtendable = true;
                 break;
             }
+
+            if (str_starts_with($path, 'vendor/hyva-themes/magento2-default-theme/' . $moduleName)) {
+                $pathToUse = 'vendor/hyva-themes/magento2-default-theme/' . $moduleName;
+                $path = str_replace($pathToUse, $pathToUse . 'view/frontend', $path);
+                list($namespace, $module) = explode('_', $moduleName);
+                $this->isMagentoExtendable = true;
+                break;
+            }
+
+            if (str_starts_with($path, 'vendor/hyva-themes/magento2-reset-theme/' . $moduleName)) {
+                $pathToUse = 'vendor/hyva-themes/magento2-reset-theme/' . $moduleName;
+                $path = str_replace($pathToUse, $pathToUse . 'view/frontend', $path);
+                list($namespace, $module) = explode('_', $moduleName);
+                $this->isMagentoExtendable = true;
+                break;
+            }
         }
 
         foreach ($this->m2->getListOfPathsToLibrarys() as $libraryPath => $libraryName) {


### PR DESCRIPTION
…f Hyvä themes.

This is a very hacky way of adding support for [Hyvä themes](https://hyva.io/) as a base theme.

Currently this tool does not support detecting changes in custom themes build on top of Hyvä themes.
For example, I was trying to upgrade Hyvä from one version to another and was hoping that this tool would help me figure out which overwritten files in our custom theme needed to be looked at. But currently the tool doesn't support this.

The PR is in WIP status, because I'm like 99% sure this isn't the correct way of adding support for this.

In fact, I believe there might be a bug in the tool which does currently not support base themes at all.
Magento adds almost all their frontend files (xml, phtml, html, js) through modules and not through their blank or luma themes.

There are currently only a few limited files that are interesting to this tool in their base themes and I think the tool currently is not able to analyse change in those files (not tested though), some numbers to demonstrate how few files are in those themes (the majority of files in those themes are `less` files):
- 0 phtml files in Magento/blank
- 0 html files in Magento/blank
- 3 js files in Magento/blank
- 5 xml files in Magento/blank
- 2 phtml files in Magento/luma
- 18 html files in Magento/luma
- 0 js files in Magento/luma
- 9 xml files in Magento/luma 

This is probably also why Hyvä themes aren't working out of the box since the 2 Hyvä themes (reset & default) do put all their frontend files inside the theme.

I'm not sure what the best way would be to support this in a more generic way that can work with all themes and random file structures, and have not a lot of time to investigate this properly unfortunately.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated

