### PR TITLE
Fix layout xml detection filename matching (#60)

### DIFF
--- a/dev/Docker/setup-magento-with-diff.sh
+++ b/dev/Docker/setup-magento-with-diff.sh
@@ -93,6 +93,9 @@ echo "//some change"  >> vendor/magento/module-sales/Block/Adminhtml/Order/Creat
 echo "<!-- -->"  >> vendor/magento/module-ui/view/base/web/templates/block-loader.html
 echo "#"  >> vendor/magento/module-customer/view/frontend/web/js/model/authentication-popup.js
 
+# Ensure change in catalog default.xml layout
+echo "<!-- -->" >> vendor/magento/module-catalog/view/frontend/layout/default.xml
+
 # Install test module and theme
 echo "Installing test module"
 cd -

--- a/dev/TestModule/app/design/frontend/Ampersand/theme/Magento_Catalog/layout/catalog_category_view_type_default.xml
+++ b/dev/TestModule/app/design/frontend/Ampersand/theme/Magento_Catalog/layout/catalog_category_view_type_default.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+
+</page>

--- a/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
+++ b/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
@@ -33,7 +33,8 @@ class LayoutFileXml extends AbstractCheck
         $area = (str_contains($file, '/adminhtml/')) ? 'adminhtml' : 'frontend';
         $module = $parts[2] . '_' . $parts[3];
 
-        $layoutFile = end($parts);
+        // Ensure layout file is like "/foo.xml" for matching against complete filenames
+        $layoutFile = '/' . end($parts);
 
         $potentialOverrides = array_filter(
             $this->m2->getListOfXmlFiles(),


### PR DESCRIPTION
Prevent matching changes like
```diff
| WARN  | Override (phtml/js/html) | vendor/magento/module-catalog/view/frontend/layout/default.xml                                                                     | app/design/frontend/Ampersand/theme/Magento_Catalog/layout/catalog_category_view_type_default.xml                                  |\n
```

Make sure it's a full filename match.

Captured in a test, and then fixed in following commit for verification.

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
