### PR TITLE
Fixes php warning about explode receiving NULL when no files could be…

### DIFF
--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -336,7 +336,12 @@ class Magento2Instance
     private function listXmlFiles(array $directories)
     {
         foreach ($directories as $dir) {
-            $files = array_filter(explode(PHP_EOL, shell_exec("find {$dir} -name \"*.xml\"")));
+            $xmlFiles = shell_exec("find {$dir} -name \"*.xml\"");
+            if (!is_string($xmlFiles)) {
+                continue;
+            }
+
+            $files = array_filter(explode(PHP_EOL, $xmlFiles));
             $this->listOfXmlFiles = array_merge($this->listOfXmlFiles, $files);
         }
 
@@ -458,7 +463,12 @@ class Magento2Instance
     private function listHtmlFiles(array $directories)
     {
         foreach ($directories as $dir) {
-            $files = array_filter(explode(PHP_EOL, shell_exec("find {$dir} -name \"*.html\"")));
+            $htmlFiles = shell_exec("find {$dir} -name \"*.html\"");
+            if (!is_string($htmlFiles)) {
+                continue;
+            }
+
+            $files = array_filter(explode(PHP_EOL, $htmlFiles));
             $this->listOfHtmlFiles = array_merge($this->listOfHtmlFiles, $files);
         }
 


### PR DESCRIPTION
… found in a certain directory.

Ran into this warning while running the tool, because our `app` directory didn't contain any `*.html` files:
```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in src/Ampersand/PatchHelper/Helper/Magento2Instance.php on line 461
```

Noticed that the same code was used for xml files, so fixed it as well over there.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
