### PR TITLE
Removed typed properties syntax (introduced in PHP 7.4) so the code c…

### DIFF
--- a/src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
+++ b/src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
@@ -11,7 +11,7 @@ class ClassPluginPhp extends AbstractCheck
     /**
      * @var string[] $vendorNamespaces
      */
-    private array $vendorNamespaces = [];
+    private $vendorNamespaces = [];
 
     /**
      * @param Magento2Instance $m2

--- a/src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php
+++ b/src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php
@@ -12,7 +12,7 @@ class ClassPreferencePhp extends AbstractCheck
     /**
      * @var string[] $vendorNamespaces
      */
-    private array $vendorNamespaces = [];
+    private $vendorNamespaces = [];
 
     /**
      * @param Magento2Instance $m2

--- a/src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php
+++ b/src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php
@@ -11,7 +11,7 @@ class SetupPatchDataPhp extends AbstractCheck
     /**
      * @var string[] $vendorNamespaces
      */
-    private array $vendorNamespaces = [];
+    private $vendorNamespaces = [];
 
     /**
      * @param Magento2Instance $m2

--- a/src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php
+++ b/src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php
@@ -11,7 +11,7 @@ class SetupPatchSchemaPhp extends AbstractCheck
     /**
      * @var string[] $vendorNamespaces
      */
-    private array $vendorNamespaces = [];
+    private $vendorNamespaces = [];
 
     /**
      * @param Magento2Instance $m2

--- a/src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php
+++ b/src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php
@@ -11,7 +11,7 @@ class SetupScriptPhp extends AbstractCheck
     /**
      * @var string[] $vendorNamespaces
      */
-    private array $vendorNamespaces = [];
+    private $vendorNamespaces = [];
 
     /**
      * @param Magento2Instance $m2


### PR DESCRIPTION
…an run again on PHP 7.2 or 7.3

Ran into this problem recently when using PHP 7.3 on a Magento 2.3.6 project
The [composer.json file](https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/blob/34a19cd6597a51a7eca99bd87c47e9d850daf062/composer.json#L14), claims minimum compatibility with PHP 7.2
After talking to @convenient on Slack, he agreed we'd best fix this.

----

Maybe it's an idea to run the built-in php linter like this in the automated tests (for each supported php version):
```
$ find bin src -iname '*.php' -exec php72 -l {} \; | grep -v 'No syntax errors'
PHP Parse error:  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php on line 15

Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php on line 15
Errors parsing src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php
PHP Parse error:  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php on line 14

Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php on line 14
Errors parsing src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php
PHP Parse error:  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php on line 14

Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php on line 14
Errors parsing src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php
PHP Parse error:  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php on line 14

Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php on line 14
Errors parsing src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php
PHP Parse error:  syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php on line 14

Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php on line 14
Errors parsing src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
```

Also https://github.com/PHPCompatibility/PHPCompatibility is able to find this:
```
$ /path/to/phpcs -s --standard=PHPCompatibility --exclude=PHPCompatibility.FunctionUse.NewFunctions --runtime-set testVersion 7.2- bin/ src/

FILE: src/Ampersand/PatchHelper/Checks/ClassPreferencePhp.php
-----------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------
 15 | ERROR | Typed properties are not supported in PHP 7.3 or earlier. Found: array
    |       | (PHPCompatibility.Classes.NewTypedProperties.Found)
-----------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Ampersand/PatchHelper/Checks/SetupScriptPhp.php
-----------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------
 14 | ERROR | Typed properties are not supported in PHP 7.3 or earlier. Found: array
    |       | (PHPCompatibility.Classes.NewTypedProperties.Found)
-----------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Ampersand/PatchHelper/Checks/SetupPatchDataPhp.php
-----------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------
 14 | ERROR | Typed properties are not supported in PHP 7.3 or earlier. Found: array
    |       | (PHPCompatibility.Classes.NewTypedProperties.Found)
-----------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Ampersand/PatchHelper/Checks/SetupPatchSchemaPhp.php
-----------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------
 14 | ERROR | Typed properties are not supported in PHP 7.3 or earlier. Found: array
    |       | (PHPCompatibility.Classes.NewTypedProperties.Found)
-----------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
-----------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------
 14 | ERROR | Typed properties are not supported in PHP 7.3 or earlier. Found: array
    |       | (PHPCompatibility.Classes.NewTypedProperties.Found)
-----------------------------------------------------------------------------------------------------------------------------------------

Time: 232ms; Memory: 8MB
```

I've excluded the `PHPCompatibility.FunctionUse.NewFunctions` rule, otherwise it complained about missing `str_starts_with` or `str_contains`, ... functions, but those are actually polyfilled by https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/blob/34a19cd6597a51a7eca99bd87c47e9d850daf062/src/functions.php

Another remark for the PHPCompatibility tool, the latest stable version only supports up to PHP 7.4, but the `develop` branch has been updated through the years for support for PHP 8.0, 8.1 & 8.2 (not fully yet, but it's able to detect a lot of issues already)

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
