### PR TITLE
Update ClassPluginPhp.php (fix #103)

### DIFF
--- a/dev/TestModule/app/code/Ampersand/Test/etc/di.xml
+++ b/dev/TestModule/app/code/Ampersand/Test/etc/di.xml
@@ -19,6 +19,7 @@
 
         <type name="Magento\AdobeIms\Model\UserProfile">
                 <plugin name="AmpersandTestPluginBeforeAfterAround3\UserProfile" type="Ampersand\Test\Plugin\AdobeImsUserProfile" sortOrder="1" />
+                <plugin name="AmpersandTestPluginBeforeAfterAround3\UserProfileNoTypeSpecified" />
                 <plugin name="somethingVirtualPlugin" type="somethingVirtualPlugin"/>
         </type>
 

--- a/src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
+++ b/src/Ampersand/PatchHelper/Checks/ClassPluginPhp.php
@@ -72,6 +72,9 @@ class ClassPluginPhp extends AbstractCheck
                     if (isset($pluginConf['disabled']) && $pluginConf['disabled']) {
                         continue;
                     }
+                    if (!isset($pluginConf['instance'])) {
+                        continue;
+                    }
                     $pluginClass = $pluginConf['instance'];
                     $pluginClass = ltrim($pluginClass, '\\');
 


### PR DESCRIPTION
See https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/103#issue-1796759590

Handle cases where the plugin definition has not been fully formed.

Without this change you [get a failure](https://app.travis-ci.com/github/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/jobs/605804690) like 
```
Test 'FunctionalTests::testMagentoTwoFourFivePointOneNoDb' started
In ClassPluginPhp.php line 78:
                                  
  Undefined array key "instance"  
                                  
analyse [-a|--auto-theme-update [AUTO-THEME-UPDATE]] [--sort-by-type] [--phpstorm-threeway-diff-commands] [--vendor-namespaces [VENDOR-NAMESPACES]] [--filter FILTER] [--pad-table-columns PAD-TABLE-COLUMNS] [--php-strict-errors] [--show-info] [--] <project>
Test 'FunctionalTests::testMagentoTwoFourFivePointOneNoDb' ended

```

### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Tests have been ran / updated
