### PR TITLE
Improve edge case handling of db_schema.xml

### DIFF
--- a/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor.patch
+++ b/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor.patch
@@ -1,6 +1,6 @@
 diff -ur -N vendor_orig/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml vendor/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml
---- vendor_orig/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml	2022-11-15 16:39:40.000000000 +0000
-+++ vendor/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml	2022-11-15 16:39:40.000000000 +0000
+--- vendor_orig/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml	2023-01-30 09:49:48
++++ vendor/ampersand/upgrade-patch-helper-test-module/src/module/etc/db_schema.xml	2023-01-30 09:49:48
 @@ -2,22 +2,22 @@
  <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
@@ -29,3 +29,20 @@ diff -ur -N vendor_orig/ampersand/upgrade-patch-helper-test-module/src/module/et
          <column xsi:type="int" name="some_id" identity="true" nullable="false" comment="some_id"/>
          <constraint xsi:type="primary" referenceId="PRIMARY">
              <column name="some_id"/>
+diff -ur -N vendor_orig/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml vendor/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml
+--- vendor_orig/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml	2023-07-11 18:07:48
++++ vendor/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml	2023-07-11 18:08:28
+@@ -1,9 +1,11 @@
+ <?xml version="1.0"?>
++<!-- Added a comment -->
+ <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+-
++    <!-- Added a comment -->
+     <table name="some_test_table_123" resource="default">
+         <column xsi:type="int" name="some_new_column" nullable="true" comment="some_new_column"/>
+     </table>
+-
++    <!-- Added a comment -->
+ </schema>
++<!-- Added a comment -->

--- a/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml
+++ b/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!-- Added a comment -->
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <!-- Added a comment -->
+    <table name="some_test_table_123" resource="default">
+        <column xsi:type="int" name="some_new_column" nullable="true" comment="some_new_column"/>
+    </table>
+    <!-- Added a comment -->
+</schema>
+<!-- Added a comment -->

--- a/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor_orig/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml
+++ b/dev/phpunit/unit/resources/checks/DbSchemaXml/vendor_orig/ampersand/upgrade-patch-helper-test-module-2/src/module/etc/db_schema.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+
+    <table name="some_test_table_123" resource="default">
+        <column xsi:type="int" name="some_new_column" nullable="true" comment="some_new_column"/>
+    </table>
+
+</schema>

--- a/src/Ampersand/PatchHelper/Checks/DbSchemaXml.php
+++ b/src/Ampersand/PatchHelper/Checks/DbSchemaXml.php
@@ -57,7 +57,7 @@ class DbSchemaXml extends AbstractCheck
                 empty($this->infos[Checks::TYPE_DB_SCHEMA_ADDED]) &&
                 empty($this->infos[Checks::TYPE_DB_SCHEMA_REMOVED])
             ) {
-                throw new \InvalidArgumentException("$vendorFile could not work out db schema changes for this diff");
+                return; // No semantic changes in this diff, most likely formatting or comments
             }
 
             /*


### PR DESCRIPTION
When only whitespace or comments (like licence info etc) were added to a `db_schema.xml` file, and you ran with `-vvv` and `--php-strict-errors` you would get an exception with

```
could not work out db schema changes for this diff
```

This is not really necessary, and gets in the way of debugging actual errors when using `-vvv --php-strict-errors`

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
