### PR TITLE
Ignore `hyva-themes/magento2-reset-theme` files

### DIFF
--- a/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
+++ b/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
@@ -17,6 +17,9 @@ class LayoutFileXml extends AbstractCheck
         if (str_contains($this->patchEntry->getPath(), '/ui_component/')) {
             return false;
         }
+        if (str_contains($this->patchEntry->getPath(), '/vendor/hyva-themes/magento2-reset-theme/')) {
+            return false;
+        }
         return pathinfo($this->patchEntry->getPath(), PATHINFO_EXTENSION) === 'xml';
     }
 

--- a/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
+++ b/src/Ampersand/PatchHelper/Checks/LayoutFileXml.php
@@ -17,7 +17,7 @@ class LayoutFileXml extends AbstractCheck
         if (str_contains($this->patchEntry->getPath(), '/ui_component/')) {
             return false;
         }
-        if (str_contains($this->patchEntry->getPath(), '/vendor/hyva-themes/magento2-reset-theme/')) {
+        if (str_contains($this->patchEntry->getPath(), 'vendor/hyva-themes/magento2-reset-theme/')) {
             return false;
         }
         return pathinfo($this->patchEntry->getPath(), PATHINFO_EXTENSION) === 'xml';

--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -184,7 +184,7 @@ class Magento2Instance
             }
             $origTheme = $theme;
             while ($theme) {
-                if (str_starts_with($theme->getCode(), 'Hyva/')) {
+                if (str_starts_with($theme->getCode(), 'Hyva/') && $theme->getCode() !== 'Hyva/reset') {
                     $this->hyvaAllThemes[$origTheme->getCode()] = $origTheme;
                 }
                 $theme = $theme->getParentTheme();

--- a/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
+++ b/src/Ampersand/PatchHelper/Helper/Magento2Instance.php
@@ -184,7 +184,7 @@ class Magento2Instance
             }
             $origTheme = $theme;
             while ($theme) {
-                if (str_starts_with($theme->getCode(), 'Hyva/') && $theme->getCode() !== 'Hyva/reset') {
+                if (str_starts_with($theme->getCode(), 'Hyva/')) {
                     $this->hyvaAllThemes[$origTheme->getCode()] = $origTheme;
                 }
                 $theme = $theme->getParentTheme();


### PR DESCRIPTION
After speaking with @peterjaap it seems that any changes made within `hyva-themes/magento2-reset-theme` can be considered safe, and not something that you need to check during an upgrade.

For example if there's a change within reset theme like to `vendor/hyva-themes/magento2-reset-theme/Magento_Contact/layout/override/base/contact_index_index.xml` it is apparently not really necessary to report that you need to check your customisations within `app/design/frontend/SomethingSuper/default/Magento_Contact/layout/contact_index_index.xml`

I am just checking with a few more hyva users if this understanding is the desired functionality before merging.

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
