### PR TITLE
Do not strip knockout comments from `.html` files

### DIFF
--- a/dev/phpunit/unit/Ampersand/PatchHelper/Checks/WebTemplateHtmlTest.php
+++ b/dev/phpunit/unit/Ampersand/PatchHelper/Checks/WebTemplateHtmlTest.php
@@ -188,4 +188,51 @@ class WebTemplateHtmlTest extends \PHPUnit\Framework\TestCase
         ];
         $this->assertEquals($expected, $ignored);
     }
+
+    /**
+     *
+     */
+    public function testWebTemplateHtmlKnockout()
+    {
+        $this->m2->expects($this->any())
+            ->method('getListOfHtmlFiles')
+            ->willReturn(
+                [
+                    'app/design/frontend/Ampersand/theme/Magento_Ui/web/templates/grid/knockout.html',
+                    'vendor/magento/module-ui/view/base/web/templates/grid/knockout.html',
+                ]
+            );
+
+        $reader = new Reader(
+            $this->testResourcesDir . 'vendor.patch'
+        );
+
+        $entries = $reader->getFiles();
+        $this->assertNotEmpty($entries, 'We should have a patch file to read');
+
+        $entry = $entries[3];
+
+        $appCodeGetter = new GetAppCodePathFromVendorPath($this->m2, $entry);
+        $appCodeFilePath = $appCodeGetter->getAppCodePathFromVendorPath();
+        $this->assertEquals(
+            'app/code/Magento/Ui/view/base/web/templates/grid/knockout.html',
+            $appCodeFilePath
+        );
+
+        $warnings = $infos = $ignored = [];
+
+        $check = new WebTemplateHtml($this->m2, $entry, $appCodeFilePath, $warnings, $infos, $ignored);
+        $this->assertTrue($check->canCheck(), 'Check should be checkable');
+        $check->check();
+
+        $this->assertEmpty($ignored, 'We should have no ignore level items');
+        $this->assertEmpty($infos, 'We should have no info level items');
+        $this->assertNotEmpty($warnings, 'We should have a warning');
+        $expectedWarnings = [
+            'Override (phtml/js/html)' => [
+                'app/design/frontend/Ampersand/theme/Magento_Ui/web/templates/grid/knockout.html'
+            ]
+        ];
+        $this->assertEquals($expectedWarnings, $warnings);
+    }
 }

--- a/dev/phpunit/unit/resources/checks/WebTemplateHtml/app/design/frontend/Ampersand/theme/Magento_Ui/web/templates/grid/knockout.html
+++ b/dev/phpunit/unit/resources/checks/WebTemplateHtml/app/design/frontend/Ampersand/theme/Magento_Ui/web/templates/grid/knockout.html
@@ -1,0 +1,1 @@
+<h1>some override</h1>

--- a/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor.patch
+++ b/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor.patch
@@ -70,3 +70,13 @@ diff -ur -N vendor_orig/magento/module-ui/view/base/web/templates/grid/some_noop
 -<!-- -->
 \ No newline at end of file
 +<!-- -->          <!-- -->                <!-- -->
+diff -ur -N vendor_orig/magento/module-ui/view/base/web/templates/grid/knockout.html vendor/magento/module-ui/view/base/web/templates/grid/knockout.html
+--- vendor_orig/magento/module-ui/view/base/web/templates/grid/knockout.html	2024-02-08 20:13:23.000000000 +0000
++++ vendor/magento/module-ui/view/base/web/templates/grid/knockout.html	2024-02-08 20:13:23.000000000 +0000
+@@ -1,5 +1,5 @@
+ <h1>hello</h1>
+ <h1>goodbye</h1>
+-<!-- ko foreach: getRegion('captcha') -->
++<!-- ko foreach: getRegion('somethingweird') -->
+ <!-- ko template: getTemplate() --><!-- /ko -->
+ <!-- /ko -->

--- a/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor/magento/module-ui/view/base/web/templates/grid/knockout.html
+++ b/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor/magento/module-ui/view/base/web/templates/grid/knockout.html
@@ -1,0 +1,5 @@
+<h1>hello</h1>
+<h1>goodbye</h1>
+<!-- ko foreach: getRegion('somethingweird') -->
+<!-- ko template: getTemplate() --><!-- /ko -->
+<!-- /ko -->

--- a/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor_orig/magento/module-ui/view/base/web/templates/grid/knockout.html
+++ b/dev/phpunit/unit/resources/checks/WebTemplateHtml/vendor_orig/magento/module-ui/view/base/web/templates/grid/knockout.html
@@ -1,0 +1,5 @@
+<h1>hello</h1>
+<h1>goodbye</h1>
+<!-- ko foreach: getRegion('captcha') -->
+<!-- ko template: getTemplate() --><!-- /ko -->
+<!-- /ko -->

--- a/src/Ampersand/PatchHelper/Patchfile/Sanitiser.php
+++ b/src/Ampersand/PatchHelper/Patchfile/Sanitiser.php
@@ -178,6 +178,6 @@ class Sanitiser
     {
         // This regular expression will match and remove both single-line <!-- ... --> comments and multi-line comments
         // spanning multiple lines. The s flag is used to make the dot (.) match any character, including newlines.
-        return preg_replace('/<!--(.*?)-->/s', '', $contents);
+        return preg_replace('/<!--(?! *ko)(.*?)-->/s', '', $contents);
     }
 }

--- a/src/Ampersand/PatchHelper/Patchfile/Sanitiser.php
+++ b/src/Ampersand/PatchHelper/Patchfile/Sanitiser.php
@@ -178,6 +178,7 @@ class Sanitiser
     {
         // This regular expression will match and remove both single-line <!-- ... --> comments and multi-line comments
         // spanning multiple lines. The s flag is used to make the dot (.) match any character, including newlines.
+        // This does not include knockout templates, as logic is embedded in comments
         return preg_replace('/<!--(?! *ko)(.*?)-->/s', '', $contents);
     }
 }


### PR DESCRIPTION
This would have been introduced as part of https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/compare/v1.18.1...v1.19.0

ChatGPT may have assisted with the regex in `src/Ampersand/PatchHelper/Patchfile/Sanitiser.php` 

For https://github.com/AmpersandHQ/ampersand-magento2-upgrade-patch-helper/issues/117

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Tests have been ran / updated
